### PR TITLE
Add puma_worker_killer and remove dead unpaginated endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "secure_headers"
 gem "sprockets-rails"
 gem "pg"
 gem "puma"
+gem "puma_worker_killer"
 gem "jbuilder"
 gem "bootsnap", require: false
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
+    get_process_mem (1.0.0)
+      bigdecimal (>= 2.0)
+      ffi (~> 1.0)
     groupdate (6.7.0)
       activesupport (>= 7.1)
     hashdiff (1.2.1)
@@ -172,6 +175,10 @@ GEM
     public_suffix (7.0.5)
     puma (7.2.0)
       nio4r (~> 2.0)
+    puma_worker_killer (1.0.0)
+      bigdecimal (>= 2.0)
+      get_process_mem (>= 0.2)
+      puma (>= 2.7)
     racc (1.8.1)
     rack (3.2.6)
     rack-cors (3.0.0)
@@ -331,6 +338,7 @@ DEPENDENCIES
   pg
   pghero
   puma
+  puma_worker_killer
   rack-cors
   rails-controller-testing
   railties (~> 8.1.1)
@@ -394,6 +402,7 @@ CHECKSUMS
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  get_process_mem (1.0.0) sha256=d54024f3bcbf776a4d6e0155ec2b21bc3ba44e2fd158c4c00c80aa8a36e0b4aa
   groupdate (6.7.0) sha256=beaa8d5bf3856814681914a1d4a20e77436a2214b85d0017dc2ea5c355fb6777
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
@@ -435,6 +444,7 @@ CHECKSUMS
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma_worker_killer (1.0.0) sha256=12dc54feecb1758df70d9f4788841423c5416aa370feda4e51e2112a5ff909e9
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-cors (3.0.0) sha256=7b95be61db39606906b61b83bd7203fa802b0ceaaad8fcb2fef39e097bf53f68

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -55,17 +55,4 @@ class Api::V1::ProjectsController < Api::V1::ApplicationController
     render json: { message: 'pong' }
   end
 
-  def packages
-    @projects = Project.joins(:list_projects).distinct.active
-      .where("repository -> 'packages' IS NOT NULL")
-      .where("jsonb_array_length(COALESCE(repository -> 'packages', '[]'::jsonb)) > 0")
-      .order(Arel.sql("(SELECT COALESCE(SUM((pkg->>'downloads')::bigint), 0) FROM jsonb_array_elements(COALESCE(repository->'packages', '[]'::jsonb)) AS pkg) DESC"))
-    fresh_when(@projects, public: true)
-  end
-
-  def images
-    @projects = Project.joins(:list_projects).distinct.with_readme
-      .where("readme ~ '!\\[.*?\\]\\(.*?\\)' OR readme ~ '<img.*?src=\".*?\"'")
-    fresh_when(@projects, public: true)
-  end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -53,8 +53,8 @@ class ListsController < ApplicationController
   end
 
   def markdown
-    @list_of_lists = List.displayable.where(list_of_lists: true).order(stars: :desc, url: :asc).all
-    @other_lists = List.displayable.where(list_of_lists: false).order(stars: :desc, url: :asc).all
+    @list_of_lists = List.displayable.where(list_of_lists: true).order(stars: :desc, url: :asc).to_a
+    @other_lists = List.displayable.where(list_of_lists: false).order(stars: :desc, url: :asc).to_a
     fresh_when([@list_of_lists, @other_lists].flatten, public: true)
     render layout: false, content_type: 'text/plain'
   end

--- a/app/views/api/v1/projects/images.json.jbuilder
+++ b/app/views/api/v1/projects/images.json.jbuilder
@@ -1,6 +1,0 @@
-json.array! @projects do |project|
-  json.extract! project, :id, :name, :description, :url, :last_synced_at, :repository, :created_at, :updated_at, :avatar_url, :category, :sub_category, :monthly_downloads
-  json.language project.language_with_default
-  json.has_new_issues project.openclimateaction_issues.any?{|issue| issue.created_at > 7.days.ago}
-  json.readme_image_urls project.readme_image_urls
-end

--- a/app/views/api/v1/projects/packages.json.jbuilder
+++ b/app/views/api/v1/projects/packages.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @projects, partial: 'api/v1/projects/project', as: :project

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,43 +1,31 @@
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
-#
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
-#
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
 port ENV.fetch("PORT") { 3000 }
 
-# Specifies the `environment` that Puma will run in.
-#
 environment ENV.fetch("RAILS_ENV") { "development" }
 
-# Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
 # preload_app!
 
-# Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+before_fork do
+  require 'puma_worker_killer'
+
+  PumaWorkerKiller.config do |config|
+    config.ram           = ENV.fetch("PWK_RAM_MB", 512).to_i
+    config.frequency     = 30
+    config.percent_usage = 0.90
+    config.rolling_restart_frequency = 6 * 3600
+    config.reaper_status_logs = true
+  end
+
+  PumaWorkerKiller.start
+end


### PR DESCRIPTION
Puma `process_rss` was consistently hitting 450-560 MB over the past 24 hours per AppSignal metrics.

- Added `puma_worker_killer` to restart workers exceeding 90% of a configurable RAM limit (`PWK_RAM_MB` env var, defaults to 512 MB), with rolling restarts every 6 hours and status logging enabled
- Removed dead `packages` and `images` actions from `Api::V1::ProjectsController` plus their jbuilder views -- both loaded full result sets without pagination and were never wired up in `routes.rb`