### PR TITLE
Speed up TopicsController#show and stop generating dead ?keyword= links

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -16,8 +16,15 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find_by!(slug: params[:id])
+
+    extra = request.query_parameters.keys - ['page']
+    if extra.any?
+      redirect_to topic_path(@topic, page: params[:page]), status: :moved_permanently
+      return
+    end
+
     scope = @topic.projects.order_by_stars.not_awesome_list
-    @lists = @topic.lists.limit(50).order_by_stars.displayable
+    @lists = @topic.lists.order_by_stars.limit(50)
     @pagy, @projects = pagy_countless(scope)
     fresh_when(@projects, public: true)
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -64,7 +64,13 @@ class Topic < ApplicationRecord
   end
 
   def categories
-    lists.map(&:category_counts).flatten(1).group_by(&:first).map{|k,v| [k, v.sum(&:last)]}.sort_by(&:last).reverse
+    Rails.cache.fetch("topic_categories/#{slug}", expires_in: 1.day) do
+      ListProject.joins(:list).merge(lists)
+        .where.not(category: nil)
+        .group(:category).count
+        .sort_by { |_, v| -v }
+        .first(50)
+    end
   end
 
   def fallback_logo_url

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -15,7 +15,7 @@
           <p>
             <% project.keywords.each do |keyword| %>
               <span class="badge bg-light text-dark">
-                <%= link_to keyword, url_for(keyword: keyword) %>
+                <%= link_to keyword, projects_path(keyword: keyword) %>
               </span>
             <% end %>
           </p>

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -16,6 +16,25 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show redirects to canonical when extra params present" do
+    topic = Topic.create!(slug: 'redir-topic', name: 'Redir', github_count: 100)
+    get topic_url(topic, keyword: 'foo')
+    assert_redirected_to topic_path(topic)
+    assert_equal 301, response.status
+  end
+
+  test "show preserves page param on canonical redirect" do
+    topic = Topic.create!(slug: 'redir-topic-2', name: 'Redir', github_count: 100)
+    get topic_url(topic, keyword: 'foo', page: 2)
+    assert_redirected_to topic_path(topic, page: 2)
+  end
+
+  test "show does not redirect with only page param" do
+    topic = Topic.create!(slug: 'paged-topic', name: 'Paged', github_count: 100)
+    get topic_url(topic, page: 1)
+    assert_response :success
+  end
+
   test "should handle show with no projects" do
     topic = Topic.create!(
       slug: 'empty-topic',

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -1,7 +1,31 @@
 require "test_helper"
 
 class TopicTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "categories aggregates list_project categories across matching lists in one query" do
+    topic = Topic.create!(slug: 'agg-topic', name: 'Agg', github_count: 100)
+
+    list1 = create(:list, keywords: ['agg-topic']).tap { |l| l.update_column(:displayable, true) }
+    list2 = create(:list, keywords: ['agg-topic']).tap { |l| l.update_column(:displayable, true) }
+    hidden = create(:list, keywords: ['agg-topic']).tap { |l| l.update_column(:displayable, false) }
+    other = create(:list, keywords: ['other']).tap { |l| l.update_column(:displayable, true) }
+
+    create(:list_project, list: list1, category: 'Tools')
+    create(:list_project, list: list1, category: 'Tools')
+    create(:list_project, list: list2, category: 'Tools')
+    create(:list_project, list: list2, category: 'Libs')
+    create(:list_project, list: hidden, category: 'Hidden')
+    create(:list_project, list: other, category: 'Other')
+    create(:list_project, list: list1, category: nil)
+
+    Rails.cache.delete("topic_categories/agg-topic")
+    result = topic.categories
+
+    assert_equal [['Tools', 3], ['Libs', 1]], result
+  end
+
+  test "categories fetches through cache keyed on slug" do
+    topic = Topic.create!(slug: 'cache-topic', name: 'Cache', github_count: 100)
+    Rails.cache.expects(:fetch).with("topic_categories/cache-topic", expires_in: 1.day).returns([['Cached', 99]])
+    assert_equal [['Cached', 99]], topic.categories
+  end
 end


### PR DESCRIPTION
Topic pages emit keyword badges via `url_for(keyword: keyword)` in `_project.html.erb`, which on `/topics/:id` resolves to `/topics/<slug>?keyword=<kw>`. The show action ignores that param, so scrapers follow every badge and re-render the same expensive page. AppSignal shows ~70M hits at ~1.2s mean.

Most of that time is `Topic#categories` in the sidebar: for `/topics/awesome` it loads 3,928 full `List` rows (including `readme`) then runs one `GROUP BY` on `list_projects` per list, ~9.6s total.

Changes:

- Point keyword badges at `projects_path(keyword: keyword)` where the param actually filters
- 301 redirect `/topics/:id` with stray query params to the canonical URL (preserving `page`)
- Replace `Topic#categories` with a single joined `GROUP BY` (~710ms on the worst topic), capped at 50 entries and cached per-slug in memcached for 1 day
- Drop redundant `.displayable` on `@lists` (already applied by `Topic#lists`)

AppSignal incident: https://appsignal.com/ecosyste-dot-ms/sites/659acdadd2a5e4aa9660b024/performance/incidents/41