### PR TITLE
Disable sessions and cookies so CDN can cache HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   before_action :set_cache_headers

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,9 @@ module Awesome
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.exceptions_app = self.routes
+
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq/web'
 require 'sidekiq-status/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_awesome_sidekiq_session'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq/web'
 require 'sidekiq-status/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_awesome_sidekiq_session'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_awesome_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -71,4 +71,23 @@ class CacheHeadersTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match /max-age=#{4.hours.to_i}/, response.headers['CDN-Cache-Control']
   end
+
+  test 'html pages do not set cookies' do
+    get '/'
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test 'topic show does not set cookies' do
+    topic = Topic.create!(slug: 'cache-topic', name: 'Cache', github_count: 100)
+    get topic_url(topic)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test 'api endpoints do not set cookies' do
+    get api_v1_topics_path(format: :json)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
 end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _awesome_session=...` header on every response. With origin cache control enabled Cloudflare returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them (disk strategy uses nginx `proxy_cache`; memory strategy has `cache_set_cookie` off by default). So the existing `Cache-Control` / `CDN-Cache-Control` headers from `set_cache_headers` are ignored and every `/topics/:slug` request reaches puma:

```
$ curl -sI https://awesome.ecosyste.ms/topics/rust
cache-control: max-age=300, public, stale-while-revalidate=3600
cdn-cache-control: max-age=14400, stale-while-revalidate=86400
set-cookie: _awesome_session=...
apisix-cache-status: MISS
cf-cache-status: BYPASS
```

During crawler bursts (~5k req/min this morning, ~80% `TopicsController#show` across unique slugs plus old `?keyword=` URLs) puma queued 25-30s of pending nginx sockets and hit the 1024 fd soft limit, which surfaced as `Errno::EMFILE` and downstream `ActiveRecord::ConnectionNotEstablished` (AppSignal incidents #112 and #80).

There's no login on this app and forgery protection was already skipped, so:

- drop `csrf_meta_tags` from the layout
- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- `request.session_options[:skip] = true` in `ApplicationController` as belt-and-braces
- give `Sidekiq::Web` its own cookie/session middleware so retry/delete buttons keep working behind basic auth
- tests asserting no `Set-Cookie` on `/`, `/topics/:id`, and API responses

`app/views/projects/_form.html.erb` is orphaned (no new/edit/create action), so no user-facing POST forms are affected.

Verify after deploy:

```
curl -sI https://awesome.ecosyste.ms/topics/rust | grep -iE 'set-cookie|cache-control|cf-cache-status|apisix'
```